### PR TITLE
Return errorElem and do not store the Ajax object

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@ var showError = function(error){
 	var errorElem = $('.templates .error').clone();
 	var errorText = '<p>' + error + '</p>';
 	errorElem.append(errorText);
+	return errorElem;
 };
 
 // takes a string of semi-colon separated tags to be searched
@@ -66,7 +67,7 @@ var getUnanswered = function(tags) {
 								order: 'desc',
 								sort: 'creation'};
 	
-	var result = $.ajax({
+	$.ajax({
 		url: "http://api.stackexchange.com/2.2/questions/unanswered",
 		data: request,
 		dataType: "jsonp",


### PR DESCRIPTION
* If the Stack Exchange API went offline, this code would fail because `showError()` is not returning `errorElem`. I added a line to return errorElem.
* Storing the jQuery Ajax object as a variable named `result `was confusing to a student of mine, since the callback method for `.done()` using a variable of the same name. There's no need to store the jQuery Ajax object so I deleted that portion of the line.